### PR TITLE
update rfc-index, update dns-rfc-annotations

### DIFF
--- a/dns-rfc-annotations.json
+++ b/dns-rfc-annotations.json
@@ -274,5 +274,12 @@
 "rfc8499": {"sections": ["dns-meta"]},
 "rfc8490": {"sections": ["core"]},
 "rfc8598": {"sections": ["dns-use"]},
-"rfc8624": {"sections": ["core"]}
+"rfc8624": {"sections": ["core"]},
+"rfc8659": {"sections": ["rrtype"]},
+"rfc8806": {"sections": ["core"]},
+"rfc8945": {"sections": ["core"]},
+"rfc9076": {"sections": ["core"]},
+"rfc9156": {"sections": ["core"]},
+"rfc9230": {"sections": ["core"]},
+"rfc9250": {"sections": ["core"]}
 }


### PR DESCRIPTION
Added DNS-over-QUIC, Oblivious DNS-over-HTTPS, and a few other RFCs that obsoleted some older ones (as reported by `convert`)